### PR TITLE
Fix namespace of external class geoPHP.

### DIFF
--- a/Classes/TceMain.php
+++ b/Classes/TceMain.php
@@ -2,6 +2,8 @@
 
 namespace Bobosch\OdsOsm;
 
+use \geoPHP;
+
 class TceMain
 {
     var $lon = array();
@@ -19,7 +21,11 @@ class TceMain
             case 'tx_odsosm_track':
                 $filename = PATH_site . 'uploads/tx_odsosm/' . $fieldArray['file'];
                 if ($fieldArray['file'] && file_exists($filename)) {
-                    require_once \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('ods_osm', 'Resources/Public/geoPHP/geoPHP.inc');
+                    // If extension is installed via composer, the class geoPHP is already known.
+                    // Otherwise we use the (older) copy out of the extension folder.
+                    if (!class_exists(geoPHP::class)) {
+                        require_once \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('ods_osm', 'Resources/Public/geoPHP/geoPHP.inc');
+                    }
                     $polygon = geoPHP::load(file_get_contents($filename), pathinfo($filename, PATHINFO_EXTENSION));
                     $box = $polygon->getBBox();
                     $fieldArray['min_lon'] = sprintf('%01.6f', $box['minx']);

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
   ],
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": "^7.2.0",
-    "typo3/cms-core": "^9.5.0"
+    "typo3/cms-core": "^9.5.0",
+    "phayes/geophp": "^1.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
If you add a track record (.kml, .gpx, ...) the 3rd party library geoPHP
is used. This has been included by this extension in the folter
Resources/public/geoPHP.

Including this way needs to specify a namespace now. This is fixed in
this patch. See issue #42.

Additionally the used external library is added as requirement in
composer.json. In case you install ods_osm via composer, also
phayes/geophp is installed and used via composer. If you install the
extension the classic way, the local copy of geoPHP is used instead.