### PR TITLE
Replace deprecated ExtensionManagementUtility::siteRelPath()

### DIFF
--- a/Classes/Provider/BaseProvider.php
+++ b/Classes/Provider/BaseProvider.php
@@ -138,5 +138,3 @@ abstract class BaseProvider
         }
     }
 }
-
-?>

--- a/Classes/Provider/Leaflet.php
+++ b/Classes/Provider/Leaflet.php
@@ -3,6 +3,9 @@
 namespace Bobosch\OdsOsm\Provider;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 
 class Leaflet extends BaseProvider
 {
@@ -16,7 +19,7 @@ class Leaflet extends BaseProvider
 
     public function getMapCore($backpath = '')
     {
-        $this->path_res = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/';
+        $this->path_res = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
         $this->path_leaflet = ($this->config['local_js'] ? $this->path_res . 'leaflet/' : 'https://cdn.leafletjs.com/leaflet-0.7.3/');
         $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(PageRenderer::class);
         $pageRenderer->addCssFile($this->path_leaflet . 'leaflet.css');
@@ -142,7 +145,7 @@ class Leaflet extends BaseProvider
         $jsElementVar = $table . '_' . $item['uid'];
         switch ($table) {
             case 'tx_odsosm_track':
-                $path = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/';
+                $path = PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
                 // Add tracks to layerswitcher
                 $this->layers[1][$item['title']] = $jsElementVar;
 
@@ -197,7 +200,7 @@ class Leaflet extends BaseProvider
                         $markerOptions['icon'] = 'icon: new L.Icon(' . json_encode($iconOptions) . ')';
                     }
                 } else {
-                    $icon = $GLOBALS['TSFE']->absRefPrefix . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/leaflet/images/marker-icon.png';
+                    $icon = $GLOBALS['TSFE']->absRefPrefix . PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/leaflet/images/marker-icon.png';
                 }
                 $jsMarker .= 'var ' . $jsElementVar . ' = new L.Marker([' . $item['latitude'] . ', ' . $item['longitude'] . '], {' . implode(',', $markerOptions) . "});\n";
                 // Add group to layer switch

--- a/Classes/Provider/Leaflet.php
+++ b/Classes/Provider/Leaflet.php
@@ -145,7 +145,7 @@ class Leaflet extends BaseProvider
         $jsElementVar = $table . '_' . $item['uid'];
         switch ($table) {
             case 'tx_odsosm_track':
-                $path = PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
+                $path = $GLOBALS['TSFE']->absRefPrefix . PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
                 // Add tracks to layerswitcher
                 $this->layers[1][$item['title']] = $jsElementVar;
 
@@ -226,5 +226,3 @@ class Leaflet extends BaseProvider
         return $jsMarker;
     }
 }
-
-?>

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -3,6 +3,8 @@
 namespace Bobosch\OdsOsm\Provider;
 
 use Bobosch\OdsOsm\Div;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 class Openlayers extends BaseProvider
 {
@@ -11,7 +13,7 @@ class Openlayers extends BaseProvider
 
     public function getMapCore($backpath = '')
     {
-        $path = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/';
+        $path = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
         $this->scripts = array(
             ($this->config['path_openlayers'] ? $this->config['path_openlayers'] : ($this->config['local_js'] ? $path . 'OpenLayers' : 'https://openlayers.org/api')) . '/OpenLayers.js',
             $path . 'tx_odsosm_openlayers.js',
@@ -141,7 +143,7 @@ class Openlayers extends BaseProvider
                     $marker = $item['tx_odsosm_marker'];
                 } else {
                     $marker = array(
-                        'icon' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/OpenLayers/img/marker.png',
+                        'icon' => PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/OpenLayers/img/marker.png',
                         'type' => 'image',
                         'size_x' => 21,
                         'size_y' => 25,

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -349,5 +349,3 @@ class Openlayers extends BaseProvider
 ";
     }
 }
-
-?>

--- a/Classes/Provider/Openlayers3.php
+++ b/Classes/Provider/Openlayers3.php
@@ -74,5 +74,3 @@ class Openlayers3 extends BaseProvider
     {
     }
 }
-
-?>

--- a/Classes/Provider/Openlayers3.php
+++ b/Classes/Provider/Openlayers3.php
@@ -3,6 +3,8 @@
 namespace Bobosch\OdsOsm\Provider;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 class Openlayers3 extends BaseProvider
 {
@@ -10,7 +12,7 @@ class Openlayers3 extends BaseProvider
 
     public function getMapCore($backpath = '')
     {
-        $path = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::siteRelPath('ods_osm') . 'Resources/Public/';
+        $path = ($backpath ? $backpath : $GLOBALS['TSFE']->absRefPrefix) . PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath('ods_osm')) . 'Resources/Public/';
         $path = ($this->config['local_js'] ? $path . 'OpenLayers3/' : 'http://ol3js.org/en/master/');
         $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(PageRenderer::class);
         $pageRenderer->addCssFile($path . 'css/ol.css');


### PR DESCRIPTION
... by `
PathUtility::stripPathSitePrefix(ExtensionManagementUtility::extPath($extensionKey))`
as mentioned in [Deprecation: #82899 - ExtensionManagementUtility methods](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Deprecation-82899-ExtensionManagementUtilityMethods.html).

Fix part of #49 .