### PR TITLE
Avoid PHP warning as the array may be empty at this line

### DIFF
--- a/Classes/Controller/PluginController.php
+++ b/Classes/Controller/PluginController.php
@@ -259,7 +259,7 @@ class PluginController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
                         ->execute();
 
                     while ($resArray = $result->fetch()) {
-                        if (!in_array($resArray['uid'],  $record_ids[$table])) {
+                        if (!in_array($resArray['uid'],  $record_ids[$table] ?? [])) {
                             $record_ids[$table][] =  $resArray['uid'];
                         }
                     }


### PR DESCRIPTION
This fixes #63. Thanks to @sypets!

This happens only if:
* you have debug mode enabled (PHP warnings are thrown as exceptions)
* the plugin has nothing set in "Marker to show" --> All records on this page are checked for markers.