### PR TITLE
[TASK] Remove show_thumbs in Flexform

### DIFF
--- a/Configuration/Flexform/flexform_basic.xml
+++ b/Configuration/Flexform/flexform_basic.xml
@@ -21,7 +21,6 @@
 								<minitems>0</minitems>
 								<maxitems>9999</maxitems>
 								<autoSizeMax>20</autoSizeMax>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker>
@@ -365,7 +364,6 @@
 								<size>1</size>
 								<minitems>0</minitems>
 								<maxitems>1</maxitems>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker_popup_initial>

--- a/Configuration/Flexform/flexform_cal.xml
+++ b/Configuration/Flexform/flexform_cal.xml
@@ -21,7 +21,6 @@
 								<minitems>0</minitems>
 								<maxitems>9999</maxitems>
 								<autoSizeMax>20</autoSizeMax>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker>
@@ -363,7 +362,6 @@
 								<size>1</size>
 								<minitems>0</minitems>
 								<maxitems>1</maxitems>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker_popup_initial>

--- a/Configuration/Flexform/flexform_cal_ttaddress.xml
+++ b/Configuration/Flexform/flexform_cal_ttaddress.xml
@@ -21,7 +21,6 @@
                                 <minitems>0</minitems>
                                 <maxitems>9999</maxitems>
                                 <autoSizeMax>20</autoSizeMax>
-                                <show_thumbs>1</show_thumbs>
                             </config>
                         </TCEforms>
                     </marker>
@@ -384,7 +383,6 @@
                                 <size>1</size>
                                 <minitems>0</minitems>
                                 <maxitems>1</maxitems>
-                                <show_thumbs>1</show_thumbs>
                             </config>
                         </TCEforms>
                     </marker_popup_initial>

--- a/Configuration/Flexform/flexform_ttaddress.xml
+++ b/Configuration/Flexform/flexform_ttaddress.xml
@@ -21,7 +21,6 @@
 								<minitems>0</minitems>
 								<maxitems>9999</maxitems>
 								<autoSizeMax>20</autoSizeMax>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker>
@@ -365,7 +364,6 @@
 								<size>1</size>
 								<minitems>0</minitems>
 								<maxitems>1</maxitems>
-								<show_thumbs>1</show_thumbs>
 							</config>
 						</TCEforms>
 					</marker_popup_initial>


### PR DESCRIPTION
The property show_thumbs for type=group is obsolete and
has been dropped from TCA in TYPO3 8.6.

If this option is not removed, it will generate entries in the deprecation log. For more information, see the [changelog](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html
).