### PR TITLE
Bugfix fix PHP 8 incompaibility

### DIFF
--- a/Classes/Div.php
+++ b/Classes/Div.php
@@ -530,11 +530,11 @@ class Div
             ];
         }
 
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ods_osm']['tables'])) {
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ods_osm']['tables'] ?? null)) {
             $tables = array_merge($tables, $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ods_osm']['tables']);
         }
 
-        return $table ? $tables[$table] : $tables;
+        return $table ? ($tables[$table] ?? []) : $tables;
     }
 
     /**

--- a/Classes/TceMain.php
+++ b/Classes/TceMain.php
@@ -206,10 +206,10 @@ class TceMain
                 $tc = Div::getTableConfig($table);
                 if (isset($tc['lon'])) {
                     if (
-                        (isset($tc['address']) && $fieldArray[$tc['address']]) ||
-                        (isset($tc['street']) && $fieldArray[$tc['street']]) ||
-                        (isset($tc['zip']) && $fieldArray[$tc['zip']]) ||
-                        (isset($tc['city']) && $fieldArray[$tc['city']])
+                        (isset($tc['address']) && ($fieldArray[$tc['address']] ?? null)) ||
+                        (isset($tc['street']) && ($fieldArray[$tc['street']] ?? null)) ||
+                        (isset($tc['zip']) && ($fieldArray[$tc['zip']] ?? null)) ||
+                        (isset($tc['city']) && ($fieldArray[$tc['city']] ?? null))
                     ) {
                         $config = Div::getConfig(array('autocomplete'));
                         // Search coordinates


### PR DESCRIPTION
If $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ods_osm']['tables'] is no array or a unconfigured table is passed to Div::getTableConfig() there will be a warning from PHP 8 on.