### PR TITLE
Fix absRefPrefix for TYPO3 10 & 11

### DIFF
--- a/Classes/Provider/BaseProvider.php
+++ b/Classes/Provider/BaseProvider.php
@@ -197,4 +197,20 @@ abstract class BaseProvider
             return 'http://' . $layer['tile_url'];
         }
     }
+
+
+    /**
+     * Get absRefPrefix in case of TYPO3 10.4
+     *
+     * @return string
+     */
+    protected function getAbsRefPrefix()
+    {
+        $absRefPrefix = '';
+        $versionInformation = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+        if ($versionInformation->getMajorVersion() == 10) {
+            $absRefPrefix = $GLOBALS['TSFE']->absRefPrefix;
+        }
+        return $absRefPrefix;
+    }
 }

--- a/Classes/Provider/Leaflet.php
+++ b/Classes/Provider/Leaflet.php
@@ -293,7 +293,7 @@ class Leaflet extends BaseProvider
                         $iconOptions['html'] = $marker['icon'];
                         $markerOptions['icon'] = 'icon: new L.divIcon(' . json_encode($iconOptions) . ')';
                     } else {
-                        $icon = $GLOBALS['TSFE']->absRefPrefix . $marker['icon']->getPublicUrl();
+                        $icon = $this->getAbsRefPrefix() . $marker['icon']->getPublicUrl();
                         $iconOptions['iconUrl'] = $icon;
                         $markerOptions['icon'] = 'icon: new L.Icon(' . json_encode($iconOptions) . ')';
                     }

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -274,7 +274,7 @@ class Openlayers extends BaseProvider
                             title: \'' .$item['title'] . '\',
                             source: new ol.source.Vector({
                                 projection: \'EPSG:3857\',
-                                url: \'' . $GLOBALS['TSFE']->absRefPrefix . $file->getPublicUrl() . '\',
+                                url: \'' . $this->getAbsRefPrefix() . $file->getPublicUrl() . '\',
                                 format: new ol.format.KML()
                             }),
                             style: ' . $jsElementVar . '_style
@@ -287,7 +287,7 @@ class Openlayers extends BaseProvider
                             title: \'' .$item['title'] . '\',
                             source: new ol.source.Vector({
                                 projection: \'EPSG:3857\',
-                                url: \'' . $GLOBALS['TSFE']->absRefPrefix . $file->getPublicUrl() . '\',
+                                url: \'' . $this->getAbsRefPrefix() . $file->getPublicUrl() . '\',
                                 format: new ol.format.GPX()
                             }),
                             style: ' . $jsElementVar . '_style
@@ -314,7 +314,7 @@ class Openlayers extends BaseProvider
 
                 if ($fileObjects) {
                     $file = $fileObjects[0];
-                    $filename = $GLOBALS['TSFE']->absRefPrefix . $file->getPublicUrl();
+                    $filename = $this->getAbsRefPrefix() . $file->getPublicUrl();
 
 
                     $jsMarker .= 'var ' . $jsElementVar . '_file = new ol.layer.Vector({
@@ -361,7 +361,7 @@ class Openlayers extends BaseProvider
                         $iconOptions['html'] = $marker['icon'];
                         $markerOptions['icon'] = 'icon: new L.divIcon(' . json_encode($iconOptions) . ')';
                     } else {
-                        $icon = $GLOBALS['TSFE']->absRefPrefix . $marker['icon']->getPublicUrl();
+                        $icon = $this->getAbsRefPrefix() . $marker['icon']->getPublicUrl();
                         $iconOptions['iconUrl'] = $icon;
                         $markerOptions['icon'] = 'icon: new L.Icon(' . json_encode($iconOptions) . ')';
                     }


### PR DESCRIPTION
In TYPO3 10, the `absRefPrefix` seems to be necessary before `getPublicUrl()`. In TYPO3 11 this breaks the URLs. So, I add a version switch. Hopefully, this works for both now.