### PR TITLE
Overrule flexform settings over TypoScript without empty values

### DIFF
--- a/Classes/Controller/PluginController.php
+++ b/Classes/Controller/PluginController.php
@@ -31,6 +31,7 @@ use Doctrine\DBAL\FetchMode;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Resource\FileRepository;
@@ -83,10 +84,10 @@ class PluginController extends AbstractPlugin
         $this->connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
 
         /* --------------------------------------------------
-            Configuration (order of priority)
-            - FlexForm
-            - TypoScript
-            - Extension
+            Configuration may be done in different places
+            - FlexForm ($flex)
+            - TypoScript ($conf)
+            - extension settings
         -------------------------------------------------- */
 
         $flex = [];
@@ -118,36 +119,40 @@ class PluginController extends AbstractPlugin
             'enable_scrollwheelzoom',
             'enable_dragging'
         );
-        foreach ($options as $option) {
-            $value = $this->pi_getFFvalue($this->cObj->data['pi_flexform'], $option, 'sDEF');
-            switch ($option) {
-                case 'lat':
-                case 'lon':
-                    if ($value != 0) {
+        // fill flex array, if there is a flexform data available
+        if ($this->cObj->data['pi_flexform'] ?? null) {
+            foreach ($options as $option) {
+                $value = $this->pi_getFFvalue($this->cObj->data['pi_flexform'] ?? null, $option, 'sDEF');
+                switch ($option) {
+                    case 'lat':
+                    case 'lon':
+                        if ($value != 0) {
+                            $flex[$option] = $value;
+                        }
+                        break;
+                    case 'marker':
+                    case 'marker_popup_initial':
+                        $flex[$option] = $this->splitGroup($value, 'tt_address');
+                        break;
+                    default:
                         $flex[$option] = $value;
-                    }
-                    break;
-                case 'marker':
-                case 'marker_popup_initial':
-                    $flex[$option] = $this->splitGroup($value, 'tt_address');
-                    break;
-                default:
-                    $flex[$option] = $value;
-                    break;
+                        break;
+                }
+            }
+            if ($flex['library'] == 'staticmap' && !empty($flex['staticmap_layer'])) {
+                $flex['layer'] = $flex['staticmap_layer'];
+            } else if (!empty($flex['base_layer'])) {
+                $flex['layer'] = $flex['base_layer'];
             }
         }
-        if ($flex['library'] == 'staticmap' && !empty($flex['staticmap_layer'])) {
-            $flex['layer'] = $flex['staticmap_layer'];
-        } else if (!empty($flex['base_layer'])) {
-            $flex['layer'] = $flex['base_layer'];
-        }
 
+        // merge configs together into $this->config
         // 1. get extension configuration
         $this->config = Div::getConfig();
-        // 2. merge with TypoScript configuration, empty values do not override
-        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $conf, true, false);
-        // 3. merge with Flexform settings, empty values do not override
-        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $flex, true, false);
+        // 2. get TypoScript settings
+        ArrayUtility::mergeRecursiveWithOverrule($this->config, $conf);
+        // 3. merge Flexform settings, but skip empty values.
+        ArrayUtility::mergeRecursiveWithOverrule($this->config, $flex, true, false);
 
         if (!is_array($this->config['marker'] ?? null)) {
             $this->config['marker'] = [];
@@ -220,7 +225,7 @@ class PluginController extends AbstractPlugin
             }
         }
 
-        $this->config['id'] = 'osm_' . ($this->cObj->data['uid'] ? : uniqid()) ;
+        $this->config['id'] = 'osm_' . ($this->cObj->data['uid'] ?? uniqid()) ;
 
         $this->config['marker'] = $this->extractGroup($this->config['marker']);
 
@@ -442,7 +447,7 @@ class PluginController extends AbstractPlugin
             }
         }
 
-        // get lon&lat
+        // get lon & lat
         foreach ($records as $table => $items) {
             foreach ($items as $uid => $row) {
                 switch ($table) {
@@ -468,8 +473,13 @@ class PluginController extends AbstractPlugin
         // No markers
         if (count($this->lons) == 0) {
             if ($this->config['no_marker'] == 1) {
-                $this->lons[] = $this->config['lon'];
-                $this->lats[] = $this->config['lat'];
+                if (($this->config['lon'] ?? false) && ($this->config['lat'] ?? false)) {
+                    $this->lons[] = $this->config['lon'];
+                    $this->lats[] = $this->config['lat'];
+                } else {
+                    $this->lons[] = $this->config['default_lon'];
+                    $this->lats[] = $this->config['default_lat'];
+                }
             }
         }
 
@@ -619,12 +629,12 @@ class PluginController extends AbstractPlugin
         /* ==================================================
             Map center
         ================================================== */
-        if ($this->config['lon'] == 0 || $this->config['use_coords_only_nomarker']) {
+        if ($this->config['lon'] ?? false || $this->config['use_coords_only_nomarker'] ?? false) {
             $lon = array_sum($this->lons) / count($this->lons);
             $lat = array_sum($this->lats) / count($this->lats);
         } else {
-            $lon = floatval($this->config['lon']);
-            $lat = floatval($this->config['lat']);
+            $lon = floatval($this->config['lon'] ?? $this->config['default_lon']);
+            $lat = floatval($this->config['lat'] ?? $this->config['default_lat']);
         }
         $zoom = intval($this->config['zoom']);
 

--- a/Classes/Controller/PluginController.php
+++ b/Classes/Controller/PluginController.php
@@ -69,7 +69,6 @@ class PluginController extends AbstractPlugin
 
     function init($conf)
     {
-        $this->conf = $conf;
         $this->pi_setPiVarDefaults();
         $this->pi_loadLL();
         $this->pi_initPIflexForm(); // Init FlexForm configuration for plugin
@@ -145,9 +144,9 @@ class PluginController extends AbstractPlugin
 
         // 1. get extension configuration
         $this->config = Div::getConfig();
-        // 2. merge with TypoScript configuration
-        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $this->conf, true, false);
-        // 3. merge with Flexform settings
+        // 2. merge with TypoScript configuration, empty values do not override
+        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $conf, true, false);
+        // 3. merge with Flexform settings, empty values do not override
         \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $flex, true, false);
 
         if (!is_array($this->config['marker'] ?? null)) {

--- a/Classes/Controller/PluginController.php
+++ b/Classes/Controller/PluginController.php
@@ -143,7 +143,13 @@ class PluginController extends AbstractPlugin
             $flex['layer'] = $flex['base_layer'];
         }
 
-        $this->config = array_merge(Div::getConfig(), $conf, $flex);
+        // 1. get extension configuration
+        $this->config = Div::getConfig();
+        // 2. merge with TypoScript configuration
+        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $this->conf, true, false);
+        // 3. merge with Flexform settings
+        \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($this->config, $flex, true, false);
+
         if (!is_array($this->config['marker'] ?? null)) {
             $this->config['marker'] = [];
         }
@@ -167,13 +173,13 @@ class PluginController extends AbstractPlugin
             $this->config['width'] .= 'px';
         }
 
-        if ($this->config['show_layerswitcher']) {
+        if ($this->config['show_layerswitcher'] ?? false) {
             $this->config['layers_visible'] = [];
         } else {
             $this->config['layers_visible'] = $this->config['layer'];
         }
 
-        if ($this->config['external_control']) {
+        if ($this->config['external_control'] ?? false) {
             if (GeneralUtility::_GP('lon')) {
                 $this->config['lon'] = GeneralUtility::_GP('lon');
             }

--- a/Classes/Provider/BaseProvider.php
+++ b/Classes/Provider/BaseProvider.php
@@ -83,7 +83,7 @@ abstract class BaseProvider
 			" . $this->getMapCenter($lat, $lon, $zoom) . "
 			" . $this->getMarkers($markers);
 
-        if ($this->config['show_layerswitcher'] ?? null) {
+        if (($this->config['show_layerswitcher'] ?? null) && ($this->config['show_layerswitcher'] > 0)) {
             $this->script .= $this->getLayerSwitcher() . "\n";
         }
 

--- a/Classes/Provider/Leaflet.php
+++ b/Classes/Provider/Leaflet.php
@@ -282,7 +282,7 @@ class Leaflet extends BaseProvider
                 break;
             default:
                 $markerOptions = [];
-                if (is_array($item['tx_odsosm_marker'])) {
+                if ($item['tx_odsosm_marker'] ?? false) {
                     $marker = $item['tx_odsosm_marker'];
                     $iconOptions = array(
                         'iconSize' => array((int)$marker['size_x'], (int)$marker['size_y']),
@@ -302,7 +302,7 @@ class Leaflet extends BaseProvider
                 }
                 $jsMarker .= 'var ' . $jsElementVar . ' = new L.Marker([' . $item['latitude'] . ', ' . $item['longitude'] . '], {' . implode(',', $markerOptions) . "});\n";
                 // Add group to layer switch
-                if ($item['group_title']) {
+                if ($item['group_title'] ?? false) {
                     $this->layers[1][] = [
                         'title' => ($marker['type'] == 'html' ? $marker['icon'] : "<img class='marker-icon' src='" . $icon . "' />") . ' ' . $item['group_title'],
                         'gid' => $item['group_uid']

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -370,7 +370,7 @@ class Openlayers extends BaseProvider
                 break;
             default:
                 $markerOptions = [];
-                if (is_array($item['tx_odsosm_marker'])) {
+                if ($item['tx_odsosm_marker'] ?? false) {
                     $marker = $item['tx_odsosm_marker'];
                     $iconOptions = array(
                         'iconSize' => array((int)$marker['size_x'], (int)$marker['size_y']),
@@ -403,7 +403,7 @@ class Openlayers extends BaseProvider
                 }
 
                 $jsMarker .= "var " . $jsElementVar . " = new ol.layer.Vector({
-                    title: '<img src=\"" .$icon . "\" class=\"marker-icon\" /> " . $item['group_title'] . "',
+                    title: '<img src=\"" .$icon . "\" class=\"marker-icon\" /> " . ($item['group_title'] ?? $item['name']) . "',
                     source: new ol.source.Vector({
                         features: [
                             new ol.Feature({

--- a/Classes/Provider/Staticmap.php
+++ b/Classes/Provider/Staticmap.php
@@ -22,17 +22,26 @@ class Staticmap extends BaseProvider
                     default:
                         $lon = $item['longitude'];
                         $lat = $item['latitude'];
-                        if (is_array($item['tx_odsosm_marker'])) {
+                        if ($item['tx_odsosm_marker'] ?? false) {
                             $marker = $item['tx_odsosm_marker'];
                             $icon = $marker['icon'];
                         } else {
-                            $marker = array('size_x' => 21, 'size_y' => 25, 'offset_x' => -11, 'offset_y' => -25);
-                            $icon = 'EXT:ods_osm/Resources/Public/JavaScript/Leaflet/Core/images/marker-icon.png';
+                            $marker = ['size_x' => 21, 'size_y' => 25, 'offset_x' => -11, 'offset_y' => -25];
+                            $icon = 'EXT:ods_osm/Resources/Public/Icons/marker-icon.png';
                         }
                         break 3;
                 }
             }
         }
+
+        // set reasonable defaults for width and height (100% and vh/vw does not work with staticmap)
+        if (intval($this->config['width']) <= 100) {
+            $this->config['width'] = 640;
+        }
+        if (intval($this->config['height']) <= 100) {
+            $this->config['height'] = 480;
+        }
+
 
         $markerUrl = array(
             '###lon###' => $lon,

--- a/Configuration/Flexform/flexform_basic.xml
+++ b/Configuration/Flexform/flexform_basic.xml
@@ -39,7 +39,6 @@
 							<config>
 								<type>input</type>
 								<size>5</size>
-								<default>80vw</default>
 							</config>
 						</TCEforms>
 					</width>
@@ -49,7 +48,6 @@
 							<config>
 								<type>input</type>
 								<size>5</size>
-								<default>80vh</default>
 							</config>
 						</TCEforms>
 					</height>
@@ -59,8 +57,6 @@
 							<config>
 								<type>input</type>
 								<size>11</size>
-								<checkbox>0.000000</checkbox>
-								<default>0.000000</default>
 								<eval>Bobosch\OdsOsm\Evaluation\LonLat</eval>
 								<fieldControl>
 									<locationMap>
@@ -172,7 +168,6 @@
 										<numIndex index="1">18</numIndex>
 									</numIndex>
 								</items>
-								<default>10</default>
 							</config>
 						</TCEforms>
 					</zoom>
@@ -201,7 +196,6 @@
 										<numIndex index="1">staticmap</numIndex>
 									</numIndex>
 								</items>
-								<default>leaflet</default>
 							</config>
 						</TCEforms>
 					</library>
@@ -291,7 +285,7 @@
 								<items type="array">
 									<numIndex index="0" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_popups.I.0</numIndex>
-										<numIndex index="1">0</numIndex>
+										<numIndex index="1">-1</numIndex>
 									</numIndex>
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_popups.I.1</numIndex>
@@ -331,7 +325,7 @@
 								<items type="array">
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_layerswitcher.I.0</numIndex>
-										<numIndex index="1">0</numIndex>
+										<numIndex index="1">-1</numIndex>
 									</numIndex>
 									<numIndex index="2" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_layerswitcher.I.1</numIndex>
@@ -342,6 +336,7 @@
 										<numIndex index="1">2</numIndex>
 									</numIndex>
 								</items>
+								<default>1</default>
 							</config>
 						</TCEforms>
 					</show_layerswitcher>
@@ -367,6 +362,7 @@
 										<numIndex index="1">2</numIndex>
 									</numIndex>
 								</items>
+								<default>2</default>
 							</config>
 						</TCEforms>
 					</layerswitcher_activationMode>

--- a/Configuration/TypoScript/Calendarize/setup.typoscript
+++ b/Configuration/TypoScript/Calendarize/setup.typoscript
@@ -4,15 +4,21 @@ plugin.tx_odsosm_pi1 {
 
     marker.tx_calendarize_domain_model_event.data = GP:tx_calendarize_calendar|index
 
+    use_coords_only_nomarker = 1
+
+    width = 480px
+    height = 360px
+
     zoom = 14
 
     layer = 1
 
     show_popups = 1
-
-    width = 100%
+    marker_popup_initial = 1
 
     show_fullscreen = 1
+
+    show_scalebar = 1
 
     library = leaflet
 }

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -2,22 +2,22 @@ plugin.tx_odsosm_pi1 {
 	# cat=OpenStreetMap//0010; type=options[none,jquery]; label=JavaScript library
 	JSlibrary = none
 
-	# cat=OpenStreetMap//0020; type=options[Leaflet=leaflet,Openlayers=openlayers,Static=static]; label=Library: Choose between http://openlayers.org/ , http://leaflet.cloudmade.com/ or a static map without javascript.
+	# cat=OpenStreetMap//0021; type=options[Leaflet=leaflet,Openlayers=openlayers,Static=staticmap]; label=Library: Choose between https://leafletjs.com/, http://openlayers.org/ or a static map without javascript.
 	library = leaflet
 
 	# cat=OpenStreetMap//0030; type=boolean; label=External control: Allow control with GET or POST.
 	external_control = 0
 
-	# cat=OpenStreetMap//1000; type=int; label=Width: Width of the map in pixels.
-	width = 640
+	# cat=OpenStreetMap//1000; type=string; label=Width: Width of the map.
+	width = 80vw
 
-	# cat=OpenStreetMap//1010; type=int; label=Height: Height of the map in pixels.
-	height = 400
+	# cat=OpenStreetMap//1010; type=string; label=Height: Height of the map.
+	height = 80vh
 
 	# cat=OpenStreetMap//1020; type=options[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]; label=Zoom: Zoom level.
 	zoom = 15
 
-	# cat=OpenStreetMap//1030; type=int; label=Base layer ID: Show this map. The user can switch between these base layers if the layerswitcher is enabled.
+	# cat=OpenStreetMap//1030; type=string; label=Base layer IDs: Show maps with the given IDs. The user can switch between these base layers if the layerswitcher is enabled.
 	layer = 1
 
 	# cat=OpenStreetMap//1040; type=boolean; label=Cluster: Cluster marker at lower map zoom.
@@ -30,7 +30,7 @@ plugin.tx_odsosm_pi1 {
 	no_marker = 1
 
 	# cat=OpenStreetMap//1060; type=boolean; label=Use coordinates only if no marker exists: Use the default coordinates only if no marker exists.
-	use_coords_only_nomarker = 0
+	use_coords_only_nomarker = 1
 
 	# cat=OpenStreetMap//1060; type=boolean; label=Position: Get current user postion from browser to center the map.
 	position = 0
@@ -38,11 +38,14 @@ plugin.tx_odsosm_pi1 {
 	# cat=OpenStreetMap//2000; type=boolean; label=Show mouse position.
 	mouse_position = 0
 
-	# cat=OpenStreetMap//2020; type=options[No=0,Click=1,Hover=2,Exclusive=3]; label=Show popup: Show popup window with record information.
-	show_popups = 0
+	# cat=OpenStreetMap//2020; type=options[No=0,Click=1,Hover=2]; label=Show popup: Show popup window with record information.
+	show_popups = 1
 
 	# cat=OpenStreetMap//2030; type=options[No=0,Closed=1,Opened=2]; label=Show layerswitcher: Show layerswitcher which allows the user to hide markers from the same group.
-	show_layerswitcher = 0
+	show_layerswitcher = 1
+
+	# cat=OpenStreetMap//2030; type=boolean; label=Show Fullscreen: Show Fullscreen Button.
+	show_fullscreen = 1
 
 	# cat=OpenStreetMap//2050; type=boolean; label=Show ScaleBar: Show a scale line on the map.
 	show_scalebar = 0

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -14,6 +14,7 @@ plugin.tx_odsosm_pi1 {
 		fe_users =
 		fe_groups =
 		tx_odsosm_track =
+		tx_odsosm_marker =
 		tt_address =
 		sys_category =
 		tx_calendarize_domain_model_event =
@@ -62,8 +63,6 @@ plugin.tx_odsosm_pi1 {
 
 	width = {$plugin.tx_odsosm_pi1.width}
 	height = {$plugin.tx_odsosm_pi1.height}
-	lon =
-	lat =
 	zoom = {$plugin.tx_odsosm_pi1.zoom}
 	layer = {$plugin.tx_odsosm_pi1.layer}
 	cluster = {$plugin.tx_odsosm_pi1.cluster}
@@ -79,10 +78,17 @@ plugin.tx_odsosm_pi1 {
 	marker_popup_initial =
 	show_layerswitcher = {$plugin.tx_odsosm_pi1.show_layerswitcher}
 	show_scalebar = {$plugin.tx_odsosm_pi1.show_scalebar}
-	layerswitcher.div = 0
-	layerswitcher.options =
 
-	_CSS_DEFAULT_STYLE = .olControlAttribution{bottom:0px!important;}
+	show_fullscreen = {$plugin.tx_odsosm_pi1.show_fullscreen}
+
+# 	Leaflet only
+	enable_scrollwheelzoom = 1
+	enable_dragging = 1
+	position = 0
+
+#	OpenLayers only
+	layerswitcher_activationMode = 1
+	mouse_position = 0
 }
 
 

--- a/Documentation/Administrators/Index.rst
+++ b/Documentation/Administrators/Index.rst
@@ -88,12 +88,6 @@ Reference
 |                 |           || 32: Stamen Terrain Labels          |         |
 |                 |           || 33: Railway Infrastructure         |         |
 +-----------------+-----------+-------------------------------------+---------+
-| layerswitcher.  | boolean   | Use extra div for the layerswitcher.| 0       |
-| div             |           |                                     |         |
-+-----------------+-----------+-------------------------------------+---------+
-| layerswitcher.  | string    | Additional options when creating    |         |
-| options         |           | layerswitcher.                      |         |
-+-----------------+-----------+-------------------------------------+---------+
 | library         | string    | Library: leaflet / openlayers /     | |ol|    |
 |                 |           | openlayers3 / static                |         |
 +-----------------+-----------+-------------------------------------+---------+

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -106,7 +106,7 @@
 				<source>Show ScaleBar</source>
 			</trans-unit>
 			<trans-unit id="tt_content.pi_flexform.show_fullscreen" xml:space="preserve">
-				<source>Show FullScreen Button</source>
+				<source>Show Fullscreen Button</source>
 			</trans-unit>
 			<trans-unit id="tt_content.pi_flexform.use_coords_only_nomarker" xml:space="preserve">
 				<source>Use this coordinates only if no marker exists</source>


### PR DESCRIPTION
This  fix #109 and #113.

The configuration is done in the following order:

1. extension configuration
2. TypoScript settings
3. Flexform settings

If the flexform setting is empty, the value of TypoScript will be used. Unfortunately, this happens to boolean values, too. So it's currently not possible to unset boolean values in flexform if it was set to `true` in TypoScript.