### PR TITLE
[BUGFIX] Add flexform manipulation to ensure valid allowed tables.

### DIFF
--- a/Classes/Backend/FormDataProvider/FlexFormManipulation.php
+++ b/Classes/Backend/FormDataProvider/FlexFormManipulation.php
@@ -1,0 +1,105 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2023 Alexander Bigga <alexander@bigga.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+namespace Bobosch\OdsOsm\Backend\FormDataProvider;
+
+/**
+ * This class is inspired by the FlexFormManipulation::class of the
+ * news extension by Georg Ringer
+ */
+
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * Manipulate flexforms of ods_osm_pi to ensure only available
+ * tables are allowed to select records.
+ */
+class FlexFormManipulation implements FormDataProviderInterface
+{
+    /**
+     * Manipulate data of ods_osm_pi plugin.
+     *
+     * @param array $result
+     * @return array
+     */
+    public function addData(array $result): array
+    {
+        if ($result['tableName'] === 'tt_content'
+            && $result['databaseRow']['CType'] === 'list'
+            && $result['databaseRow']['list_type'] === 'ods_osm_pi1'
+            && is_array($result['processedTca']['columns']['pi_flexform']['config']['ds'])
+        ) {
+            // get flexform data structure
+            $dataStructure = $result['processedTca']['columns']['pi_flexform']['config']['ds'];
+
+            // check / manipulate data structure
+            $dataStructure = $this->fixAllowedTables($dataStructure);
+
+            // set checked data structure
+            $result['processedTca']['columns']['pi_flexform']['config']['ds'] = $dataStructure;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check for optionally installed extensions and add the
+     * corresponding tables to the list of allowed tables for marker.
+     *
+     * @param array &$dataStructure flexform structure
+     * @return array Modified structure
+     */
+    protected function fixAllowedTables(array $dataStructure): array
+    {
+        $markerAllowedTables = [ 'fe_users', 'fe_groups', 'pages', 'sys_category', 'tx_odsosm_track', 'tx_odsosm_vector' ];
+        $markerPopupInitialAllowedTables = [ 'fe_users' ];
+
+        $extensions = [
+            'tt_address' => 'tt_address',
+            'calendarize' => 'tx_calendarize_domain_model_event'
+        ];
+
+        foreach ($extensions as $extension => $table) {
+            if (ExtensionManagementUtility::isLoaded($extension)) {
+                $markerAllowedTables[] = $table;
+                $markerPopupInitialAllowedTables[] = $table;
+            }
+        }
+
+        // set manipulated value for marker -> config -> allowed
+        if ($dataStructure['sheets']['sDEF']['ROOT']['el']['marker']['config']['allowed'] ?? false) {
+            $dataStructure['sheets']['sDEF']['ROOT']['el']['marker']['config']['allowed'] = implode(',', $markerAllowedTables);
+        }
+
+        // set manipulated value for marker_popup_initial -> config -> allowed
+        if ($dataStructure['sheets']['sDEF']['ROOT']['el']['marker_popup_initial']['config']['allowed'] ?? false) {
+            $dataStructure['sheets']['sDEF']['ROOT']['el']['marker_popup_initial']['config']['allowed'] = implode(',', $markerPopupInitialAllowedTables);
+        }
+
+        return $dataStructure;
+    }
+
+}

--- a/Configuration/Flexform/flexform_basic.xml
+++ b/Configuration/Flexform/flexform_basic.xml
@@ -17,7 +17,7 @@
 							<config>
 								<type>group</type>
 								<internal_type>db</internal_type>
-                                <allowed>fe_groups,fe_users,pages,sys_category,tx_odsosm_track,tx_odsosm_vector,*</allowed>
+								<allowed>fe_groups,fe_users,pages,sys_category,tx_odsosm_track,tx_odsosm_vector</allowed>
 								<size>5</size>
 								<minitems>0</minitems>
 								<maxitems>9999</maxitems>
@@ -90,7 +90,7 @@
 							<label>LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.zoom</label>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="0" type="array">
 										<numIndex index="0"></numIndex>
@@ -178,7 +178,7 @@
 							<onChange>reload</onChange>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="0" type="array">
 										<numIndex index="0"></numIndex>
@@ -208,7 +208,7 @@
 							<config>
 								<type>select</type>
 								<size>3</size>
-                                <renderType>selectMultipleSideBySide</renderType>
+								<renderType>selectMultipleSideBySide</renderType>
 								<minitems>0</minitems>
 								<maxitems>99</maxitems>
 								<autoSizeMax>20</autoSizeMax>
@@ -225,7 +225,7 @@
 							<config>
 								<type>select</type>
 								<size>3</size>
-                                <renderType>selectMultipleSideBySide</renderType>
+								<renderType>selectMultipleSideBySide</renderType>
 								<minitems>0</minitems>
 								<maxitems>99</maxitems>
 								<autoSizeMax>20</autoSizeMax>
@@ -247,7 +247,7 @@
 							<config>
 								<type>select</type>
 								<size>3</size>
-                                <renderType>selectMultipleSideBySide</renderType>
+								<renderType>selectMultipleSideBySide</renderType>
 								<minitems>0</minitems>
 								<maxitems>99</maxitems>
 								<autoSizeMax>20</autoSizeMax>
@@ -262,7 +262,7 @@
 							<displayCond>FIELD:library:=:staticmap</displayCond>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<foreign_table>tx_odsosm_layer</foreign_table>
 								<foreign_table_where>AND tx_odsosm_layer.hidden=0 AND tx_odsosm_layer.static_url!="" ORDER BY tx_odsosm_layer.sorting</foreign_table_where>
 								<items type="array">
@@ -282,7 +282,7 @@
 							<onChange>reload</onChange>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="0" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_popups.I.0</numIndex>
@@ -304,13 +304,11 @@
 					<marker_popup_initial>
 						<TCEforms>
 							<label>LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.marker_popup_intial</label>
-							<description>LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.marker_popup_intial.description</description>
 							<displayCond>FIELD:show_popups:IN:1,3</displayCond>
 							<config>
 								<type>group</type>
 								<internal_type>db</internal_type>
-								<allowed>fe_users,*</allowed>
-								<prepend_tname>1</prepend_tname>
+								<allowed>fe_users</allowed>
 								<size>1</size>
 								<minitems>0</minitems>
 								<maxitems>1</maxitems>
@@ -324,7 +322,7 @@
 							<onChange>reload</onChange>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_layerswitcher.I.0</numIndex>
@@ -354,7 +352,7 @@
 							</displayCond>
 							<config>
 								<type>select</type>
-                                <renderType>selectSingle</renderType>
+								<renderType>selectSingle</renderType>
 								<items type="array">
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:ods_osm/Resources/Private/Language/locallang_db.xlf:tt_content.pi_flexform.show_popups.I.1</numIndex>

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -7,7 +7,7 @@
 EXT: ods_osm (OpenStreetMap)
 ============================
 
-:Author:    Robert Heel <typo3@bobosch.de>
+:Author:    Robert Heel <typo3@bobosch.de>, Alexander Bigga <alexander@bigga.de>
 :License:   GPL 3.0
 :Rendered:  |today|
 :Description:

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,5 +1,5 @@
 [general]
-project     = ODS OSM
+project     = OSM
 release     = 4.1
 description = Add an interactive OpenStreetMap map to your website.
               Can also show other OpenLayers compatible maps.

--- a/Documentation/Tutorial/Index.rst
+++ b/Documentation/Tutorial/Index.rst
@@ -9,7 +9,7 @@ The following steps are tested with TYPO3 11.5 LTS.
 
    ``composer require bobosch/ods-osm:^4.1``
 
-2. Install tt_address
+2. Install tt_address (optional)
 
    ``composer req friendsoftypo3/tt-address``
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,6 +30,16 @@ mod.wizards.newContentElement.wizardItems.plugins.show := addToList(odsosm)
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \Bobosch\OdsOsm\TceMain::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][\Bobosch\OdsOsm\Evaluation\LonLat::class] = '';
 
+// Modify flexform fields since core 8.5 via formEngine: Inject a data provider between TcaFlexPrepare and TcaFlexProcess
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\Bobosch\OdsOsm\Backend\FormDataProvider\FlexFormManipulation::class] = [
+    'depends' => [
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexPrepare::class,
+    ],
+    'before' => [
+        \TYPO3\CMS\Backend\Form\FormDataProvider\TcaFlexProcess::class,
+    ],
+];
+
 // Add wizard with map for setting geo location
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1616876515] = [
     'nodeName' => 'coordinatepickerWizard',


### PR DESCRIPTION
The flexform field "marker" use the group element (`type="group"`) to reference to marker, addresses, tracks, etc.

The option `allowed` keeps a list of allowed tables for the element browser. This browser makes it easy to select the records.

Unfortunately, if a table does not exist, there is thrown an exception in TYPO3 11.

This flexform manipulation makes sure to always have to proper list of allowed tables. Of course, this assumes, that all installed extensions have created the corresponding tables.