### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Controller/PluginController.php
+++ b/Classes/Controller/PluginController.php
@@ -393,7 +393,7 @@ class PluginController extends AbstractPlugin
                             $constraints = Div::getConstraintsForQueryBuilder($foreign, $this->cObj, $queryBuilder);
 
                             // set uid
-                            $constraints[] = $queryBuilder->expr()->eq($local . '.uid', $queryBuilder->createNamedParameter($item, \PDO::PARAM_INT));
+                            $constraints[] = $queryBuilder->expr()->eq($local . '.uid', $queryBuilder->createNamedParameter($item, Connection::PARAM_INT));
 
                             $rows = $queryBuilder
                                 ->select($foreign . '.*')

--- a/Classes/Div.php
+++ b/Classes/Div.php
@@ -9,6 +9,7 @@ use TYPO3\CMS\Core\Log\Logger;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\ParameterType;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer;
 use TYPO3\CMS\Core\Http\RequestFactory;
@@ -35,21 +36,21 @@ class Div
 
             // Version
             $constraints[] =
-                $queryBuilder->expr()->gte($table . '.pid', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT));
+                $queryBuilder->expr()->gte($table . '.pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT));
 
             // Translation
             if ($ctrl['languageField'] ?? null) {
                 $orConstraints = [
-                        $queryBuilder->expr()->eq($table . '.' . $ctrl['languageField'], $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)),
-                        $queryBuilder->expr()->eq($table . '.' . $ctrl['languageField'], $queryBuilder->createNamedParameter(-1, \PDO::PARAM_INT))
+                        $queryBuilder->expr()->eq($table . '.' . $ctrl['languageField'], $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                        $queryBuilder->expr()->eq($table . '.' . $ctrl['languageField'], $queryBuilder->createNamedParameter(-1, Connection::PARAM_INT))
                     ];
 
                 $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
 
                 if ($languageAspect->getContentId() && $ctrl['transOrigPointerField']) {
                     $orConstraints[] = $queryBuilder->expr()->and($queryBuilder->expr()->eq($table . '.' . $ctrl['languageField'],
-                        $queryBuilder->createNamedParameter((int) $languageAspect->getContentId(), \PDO::PARAM_INT)), $queryBuilder->expr()->eq($table . '.' . $ctrl['transOrigPointerField'],
-                        $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)));
+                        $queryBuilder->createNamedParameter((int) $languageAspect->getContentId(), Connection::PARAM_INT)), $queryBuilder->expr()->eq($table . '.' . $ctrl['transOrigPointerField'],
+                        $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)));
                 }
                 $constraints[] = $queryBuilder->expr()->or(...$orConstraints);
             }

--- a/Classes/Updates/FileLocationUpdater.php
+++ b/Classes/Updates/FileLocationUpdater.php
@@ -34,6 +34,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Resource\File;
@@ -292,13 +293,13 @@ class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, Lo
             $queryBuilder = $connectionPool->getQueryBuilderForTable('sys_file');
             $existingFileRecord = $queryBuilder->select('uid')->from('sys_file')->where($queryBuilder->expr()->eq(
                 'missing',
-                $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
             ), $queryBuilder->expr()->eq(
                 'sha1',
                 $queryBuilder->createNamedParameter($fileSha1, \PDO::PARAM_STR)
             ), $queryBuilder->expr()->eq(
                 'storage',
-                $queryBuilder->createNamedParameter($storageUid, \PDO::PARAM_INT)
+                $queryBuilder->createNamedParameter($storageUid, Connection::PARAM_INT)
             ))->executeQuery()->fetch();
 
             // the file exists, the file does not have to be moved again
@@ -368,7 +369,7 @@ class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, Lo
             $queryBuilder->update($table)->where(
                 $queryBuilder->expr()->eq(
                     'uid',
-                    $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter($row['uid'], Connection::PARAM_INT)
                 )
             )->set($this->fieldsToMigrate[$table], $i)->executeStatement();
         }

--- a/Classes/Updates/MigrateSettings.php
+++ b/Classes/Updates/MigrateSettings.php
@@ -24,6 +24,7 @@
 
 namespace Bobosch\OdsOsm\Updates;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -106,7 +107,7 @@ class MigrateSettings implements UpgradeWizardInterface
                 ->where(
                     $queryBuilder->expr()->eq(
                         'uid',
-                        $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT)
+                        $queryBuilder->createNamedParameter($record['uid'], Connection::PARAM_INT)
                     )
                 )->set('pi_flexform', $newXml)->executeStatement();
 


### PR DESCRIPTION
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.