### PR TITLE
[TASK] Use Connection instead of PDO

### DIFF
--- a/Classes/Updates/FileLocationUpdater.php
+++ b/Classes/Updates/FileLocationUpdater.php
@@ -197,7 +197,7 @@ class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, Lo
                         $queryBuilder->expr()->isNotNull($this->fieldsToMigrate[$table]),
                         $queryBuilder->expr()->neq(
                             $this->fieldsToMigrate[$table],
-                            $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                            $queryBuilder->createNamedParameter('', Connection::PARAM_STR)
                         ),
                         $queryBuilder->expr()->comparison(
                             'CAST(CAST(' . $queryBuilder->quoteIdentifier($this->fieldsToMigrate[$table]) . ' AS DECIMAL) AS CHAR)',
@@ -296,7 +296,7 @@ class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, Lo
                 $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
             ), $queryBuilder->expr()->eq(
                 'sha1',
-                $queryBuilder->createNamedParameter($fileSha1, \PDO::PARAM_STR)
+                $queryBuilder->createNamedParameter($fileSha1, Connection::PARAM_STR)
             ), $queryBuilder->expr()->eq(
                 'storage',
                 $queryBuilder->createNamedParameter($storageUid, Connection::PARAM_INT)


### PR DESCRIPTION
In Doctrine DBAL v4, as described in the [documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Database/QueryBuilder/Index.html#database-query-builder-create-named-parameter), support for using the `\PDO::PARAM_*` constants has been dropped in favor of the enum types. This should be migrated to `Connection::PARAM_*` in order to be compatible with TYPO3 v13 later on. `Connection::PARAM_*` can already be used now as it is compatible with TYPO3 11 and 12.