### PR TITLE
[BUGFIX] Use extension name instead of extension key

### DIFF
--- a/Classes/Provider/BaseProvider.php
+++ b/Classes/Provider/BaseProvider.php
@@ -182,7 +182,7 @@ abstract class BaseProvider
         $popupcode = '';
         if ($this->config['library'] == 'openlayers') {
             if ($this->config['mouse_position']) {
-                $mousePosition = '<div id="mouse-position-' . $this->config['id'] . '">' . LocalizationUtility::translate('mouse_position', 'ods_osm') . ':&nbsp;</div>';
+                $mousePosition = '<div id="mouse-position-' . $this->config['id'] . '">' . LocalizationUtility::translate('mouse_position', 'OdsOsm') . ':&nbsp;</div>';
             }
             $popupcode = '
                 <div id="popup" class="ol-popup">

--- a/Classes/Provider/Leaflet.php
+++ b/Classes/Provider/Leaflet.php
@@ -253,7 +253,7 @@ class Leaflet extends BaseProvider
 
                     // Add vector file to layerswitcher
                     $this->layers[1][] = [
-                        'title' => $item['title'] . ' ('. LocalizationUtility::translate('file', 'ods_osm') .')',
+                        'title' => $item['title'] . ' ('. LocalizationUtility::translate('file', 'OdsOsm') .')',
                         'table' => $table,
                         'uid' => $item['uid'] . '_file'
                     ];

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -96,7 +96,7 @@ class Openlayers extends BaseProvider
 
         baselayergroup = new ol.layer.Group({
             name: 'baselayergroup',
-            title: '" . LocalizationUtility::translate('base_layer', 'ods_osm') . "',
+            title: '" . LocalizationUtility::translate('base_layer', 'OdsOsm') . "',
             layers: [
                 new ol.layer.Tile({
                     type: 'base',
@@ -107,14 +107,14 @@ class Openlayers extends BaseProvider
 
         overlaygroup = new ol.layer.Group({
             name: 'overlaygroup',
-            title: '" . LocalizationUtility::translate('overlays', 'ods_osm') . "',
+            title: '" . LocalizationUtility::translate('overlays', 'OdsOsm') . "',
             layers: []
         });
 
         const styleCache = {};
         clusters = new ol.layer.Vector({
             name: 'clusters',
-            title: '" . LocalizationUtility::translate('openlayers.clusterLayer', 'ods_osm') . "',
+            title: '" . LocalizationUtility::translate('openlayers.clusterLayer', 'OdsOsm') . "',
             source: new ol.source.Cluster({
                 distance: " . (int)$this->config['cluster_radius']  . ",
                 minDistance: 10,
@@ -255,8 +255,8 @@ class Openlayers extends BaseProvider
          var layerSwitcher = new ol.control.LayerSwitcher({
             activationMode: \'' . ($this->config['layerswitcher_activationMode'] == '1' ? 'click' : 'mouseover') . '\',
             startActive: ' . ($this->config['show_layerswitcher'] == '2' ? 'true' : 'false') . ',
-            tipLabel: \'' . LocalizationUtility::translate('openlayers.showLayerList', 'ods_osm') . '\',
-            collapseTipLabel: \'' . LocalizationUtility::translate('openlayers.hideLayerList', 'ods_osm') . '\',
+            tipLabel: \'' . LocalizationUtility::translate('openlayers.showLayerList', 'OdsOsm') . '\',
+            collapseTipLabel: \'' . LocalizationUtility::translate('openlayers.hideLayerList', 'OdsOsm') . '\',
             groupSelectStyle: \'children\',
             reverse: false
           });
@@ -498,7 +498,7 @@ class Openlayers extends BaseProvider
 
                     $jsMarker .= 'var ' . $jsElementVar . '_file_properties = ' . json_encode($properties) . ';';
                     $jsMarker .= 'var ' . $jsElementVar . '_file = new ol.layer.Vector({
-                        title: \'' .$item['title'] . ' ('. LocalizationUtility::translate('file', 'ods_osm') .')\',
+                        title: \'' .$item['title'] . ' ('. LocalizationUtility::translate('file', 'OdsOsm') .')\',
                         source: new ol.source.Vector({
                             projection: \'EPSG:3857\',
                             url: \'' . $filename . '\',


### PR DESCRIPTION
The method expects the extension name instead of the extension key.