### PR TITLE
[BUGFIX] Fix access to array entry city

### DIFF
--- a/Classes/Div.php
+++ b/Classes/Div.php
@@ -368,8 +368,10 @@ class Div
                 if ($result[0]['address']['postcode'] ?? false) {
                     $address['zip'] = (string)$result[0]['address']['postcode'];
                 }
-                if (($result[0]['address']['city'] ?? false) || ($result[0]['address']['village'] ?? false)) {
-                    $address['city'] = $result[0]['address']['city'] ? (string)$result[0]['address']['city'] : (string)$result[0]['address']['village'];
+                if ($result[0]['address']['city'] ?? false) {
+                    $address['city'] = $result[0]['address']['city'];
+                } else if ($result[0]['address']['village'] ?? false) {
+                    $address['city'] = (string)$result[0]['address']['village'];
                 }
                 if ($result[0]['address']['state'] ?? false) {
                     $address['state'] = (string)$result[0]['address']['state'];


### PR DESCRIPTION
When searching for addresses in Div::searchAddressNominatim, an array entry 'city' is now only accessed if it exists.

Resolves: #178