### PR TITLE
[TASK] Robust checks in TceMain

### DIFF
--- a/Classes/TceMain.php
+++ b/Classes/TceMain.php
@@ -36,6 +36,10 @@ class TceMain
         array $fieldArray,
         DataHandler $parentObject
     ): void {
+        // guard statement, abort here if no ods_osm table
+        if (strpos($table, 'tx_odsosm_') !== 0) {
+            return;
+        }
         /*
          * The id may be integer already or the temporary NEW id. This depends, how the record was created
          *
@@ -55,7 +59,7 @@ class TceMain
          */
 
         if ($status == "new") {
-            $id = $parentObject->substNEWwithIDs[$id];
+            $id = $parentObject->substNEWwithIDs[$id] ?? '';
         }
 
         if (!is_int($id)) {


### PR DESCRIPTION
In processDatamap_afterDatabaseOperations, return right away if $table is not a table, this function should handle.

Also use null coalesce when accessing the id in
$parentObject->substNEWwithIDs because there may be some scenarios where this is not set properly.

Resolves: #190