### PR TITLE
Fix apostrophe and quotation marks breaking JavaScript code

### DIFF
--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -600,7 +600,7 @@ class Openlayers extends BaseProvider
                 } else {
                     $jsMarker .= $markerStyle;
                     $jsMarker .= "var " . $jsElementVar . " = new ol.layer.Vector({
-                        title: '<img src=\"" .$icon . "\" class=\"marker-icon\" /> " . ($item['group_title'] ?? $item['name']) . "',
+                        title: '<img src=\"" .$icon . "\" class=\"marker-icon\" /> " . Openlayers::escapeEntities($item['group_title'] ?? $item['name']) . "',
                         source: new ol.source.Vector({
                             features: [
                                  new ol.Feature({
@@ -620,5 +620,20 @@ class Openlayers extends BaseProvider
             }
 
         return $jsMarker;
+    }
+    
+    /**
+     * Replaces ' and " charactes with HTML entities.
+     *
+     * @param string $text
+     *              Text to escape.
+     * @return string
+     *              Text with HTML entities for ' and " characters.
+     */
+    private static function escapeEntities(string $text) : string
+    {
+        $escaped = str_replace("'", "&apos;", $text);
+        $escaped = str_replace('"', "&quot;", $escaped);
+        return $escaped;
     }
 }

--- a/Classes/Provider/Openlayers.php
+++ b/Classes/Provider/Openlayers.php
@@ -540,7 +540,7 @@ class Openlayers extends BaseProvider
                         $markerOptions['icon'] = 'icon: new L.Icon(' . json_encode($icon) . ')';
                     }
                 } else {
-                    $icon = '/typo3conf/ext/ods_osm/Resources/Public/Icons/marker-icon.png';
+                    $icon = \TYPO3\CMS\Core\Utility\PathUtility::getPublicResourceWebPath('EXT:ods_osm/Resources/Public/Icons/marker-icon.png');
                     $marker['size_x'] = 25;
                     $marker['size_y'] = 41;
                 }


### PR DESCRIPTION
This fix prevents broken JavaScript code caused by apostrophes and quotation marks in marker title through replacing with HTML entities. 